### PR TITLE
add oreo focus-visible styling

### DIFF
--- a/src/PlanetaryAlignment.vue
+++ b/src/PlanetaryAlignment.vue
@@ -28,7 +28,9 @@
         <font-awesome-icon
           id="close-splash-button"
           @click="closeSplashScreen"
+          @keyup.enter="closeSplashScreen"
           icon="xmark"
+          tabindex="0"
           />
         <div id="splash-screen-text">
           <pp>Want to see the</pp>
@@ -1008,6 +1010,15 @@ body {
   }
 }
 
+// From Sara Soueidan (https://www.sarasoueidan.com/blog/focus-indicators/) & Erik Kroes (https://www.erikkroes.nl/blog/the-universal-focus-state/)
+:focus-visible,
+button:focus-visible,
+.focus-visible,
+.v-selection-control--focus-visible .v-selection-control__input {
+  outline: 9px double white !important;
+  box-shadow: 0 0 0 6px black !important;
+  border-radius: .125rem;
+}
 
 
 .video-wrapper {


### PR DESCRIPTION
Applying the same keyboard accessibility focus styling that we use in tempo-lite