### PR TITLE
Updates related to planet sprites

### DIFF
--- a/src/PlanetaryAlignment.vue
+++ b/src/PlanetaryAlignment.vue
@@ -355,7 +355,7 @@ import { formatInTimeZone } from "date-fns-tz";
 
 import { useTimezone } from "./timezones";
 import { equatorialToHorizontal, horizontalToEquatorial } from "./utils";
-import { resetAltAzGridText, makeAltAzGridText, renderOneFrame } from "./wwt-hacks";
+import { resetAltAzGridText, makeAltAzGridText, drawPlanets, renderOneFrame } from "./wwt-hacks";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
 const MILLISECONDS_PER_DAY = 1000 * SECONDS_PER_DAY;
@@ -442,6 +442,7 @@ function doWWTModifications() {
     }
   }
   Planets.updatePlanetLocations = newUpdatePlanetLocations;
+  Planets.drawPlanets = drawPlanets;
 
   // Recall that zoom = 6 * FOV, in WWT
   const maxFOV = 90;

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -230,8 +230,8 @@ export function renderOneFrame(showHorizon=true,
     }
   }
   this.constellation = Constellations.containment.findConstellationForPoint(this.renderContext.viewCamera.get_RA(), this.renderContext.viewCamera.get_dec());
-  Planets.drawPlanets(this.renderContext, 1);
   this._drawSkyOverlays();
+  Planets.drawPlanets(this.renderContext, 1);
 
   if (showPlanetLabels) {
     this._planetTextOverlays = makeTextOverlays();


### PR DESCRIPTION
This PR fixes #12 and #13 - it removes the Galilean moons (actually all of the moons of other planets), and moves the planet sprites in front of the alt/az grid.