### PR TITLE
Use spacebar for play/pause functionality

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -758,6 +758,17 @@ onMounted(() => {
         showVideoSheet.value = false;
       }
     });
+    
+    function notkeycombo(event: KeyboardEvent) {
+      return !(event.ctrlKey || event.shiftKey || event.metaKey);
+    }
+    window.addEventListener("keyup", (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if ([" ", "Spacebar", "Space"].includes(event.key) || event.code == "Space" && notkeycombo(event)) {
+        playing.value = !playing.value;
+      }
+    });
 
     window.addEventListener("visibilitychange", () => {
       if (document.visibilityState === "hidden") {


### PR DESCRIPTION
Use the spacebar for play pause. Taking this over has the secondary effect that spacebar cannot be used for toggling the checkmark or other things. this seems like an accessiblity concern. the checkboxes indicate the space or enter are valid, but then it won't be.