### PR TITLE
Track video evaluation data

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -548,8 +548,13 @@ if (!existingUser) {
   window.localStorage.setItem(UUID_KEY, uuid);
 }
 let infoTimeMs = 0;
+let videoPlayingTimeMs = 0;
+let videoPlaying = false;
+let videoOpened = false;
+let videoPlayed = false;
 let appStartTimestamp = Date.now();
 let infoStartTimestamp = null as number | null;
+let videoPlayingStartTimestamp = null as number | null;
 
 let userSelectedSearchLocations: [number, number][] = [];
 let userSelectedMapLocations: [number, number][] = [];
@@ -766,7 +771,6 @@ onMounted(() => {
         resetData();
       }
     });
-
   });
 });
 
@@ -821,6 +825,24 @@ const showVideoSheet = computed({
     if (!value) {
       const video = document.querySelector("#info-video") as HTMLVideoElement;
       video.pause();
+    } else {
+      nextTick(() => {
+        const video = document.querySelector("#info-video") as HTMLVideoElement;
+        video.addEventListener("play", (_event: Event) => {
+          videoPlaying = true;
+          videoPlayingStartTimestamp = Date.now();
+          videoPlayed = true;
+        });
+
+        video.addEventListener("pause", (_event: Event) => {
+          videoPlaying = false;
+          const now = Date.now();
+          if (videoPlayingStartTimestamp !== null) {
+            videoPlayingTimeMs += (now - videoPlayingStartTimestamp);
+            videoPlayingStartTimestamp = null;
+          }
+        });
+      });
     }
   }
 });
@@ -907,9 +929,9 @@ async function createUserEntry() {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       user_selected_map_locations: userSelectedMapLocations,
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      app_time_ms: 0,
+      app_time_ms: 0, info_time_ms: 0, video_time_ms: 0,
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      info_time_ms: 0,
+      video_opened: videoOpened, video_played: videoPlayed,
     }),
   });
 }
@@ -918,9 +940,11 @@ function resetData() {
   userSelectedMapLocations = [];
   userSelectedSearchLocations = [];
   infoTimeMs = 0;
+  videoPlayingTimeMs = 0;
   const now = Date.now();
   appStartTimestamp = now;
   infoStartTimestamp = showTextSheet.value ? now : null;
+  videoPlayingStartTimestamp = videoPlaying ? now : null;
 }
 
 async function updateUserData() {
@@ -930,6 +954,7 @@ async function updateUserData() {
 
   const now = Date.now();
   const infoTime = (showTextSheet.value && infoStartTimestamp !== null) ? now - infoStartTimestamp : infoTimeMs;
+  const videoTime = (videoPlaying && videoPlayingStartTimestamp !== null) ? now - videoPlayingStartTimestamp : videoPlayingTimeMs;
 
   fetch(`${STORY_DATA_URL}/${uuid}`, {
     method: "PATCH",
@@ -947,6 +972,10 @@ async function updateUserData() {
       delta_app_time_ms: now - appStartTimestamp,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       delta_info_time_ms: infoTime,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      delta_video_time_ms: videoTime,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      video_opened: videoOpened, video_played: videoPlayed,
     }),
     keepalive: true,
   }).then(() => {
@@ -1041,6 +1070,12 @@ watch(showTextSheet, (show: boolean) => {
   } else if (infoStartTimestamp !== null) {
     infoTimeMs += (now - infoStartTimestamp);
     infoStartTimestamp = null;
+  }
+});
+
+watch(showVideoSheet, (show: boolean) => {
+  if (show) {
+    videoOpened = true;
   }
 });
 


### PR DESCRIPTION
This PR resolves #32. It tracks whether the video sheet has been opened, whether the video has been played, and how long the video was played for. The associated server PR is https://github.com/cosmicds/cds-api/pull/173.

Note that once a user has opened/played the video, these values will not be updated to false server-side (i.e. an update message can't unset these flags).