### PR TITLE
Associate cardinal direction labels to horizon/sky rather than grid

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -538,7 +538,7 @@ import { v4 } from "uuid";
 
 import { useTimezone } from "./timezones";
 import { equatorialToHorizontal, horizontalToEquatorial } from "./utils";
-import { resetAltAzGridText, makeAltAzGridText, drawPlanets, renderOneFrame, drawEcliptic } from "./wwt-hacks";
+import { resetAltAzGridText, makeAltAzGridText, drawPlanets, renderOneFrame, drawEcliptic, drawSkyOverlays } from "./wwt-hacks";
 import { MapBoxFeature, MapBoxFeatureCollection, geocodingInfoForSearch, textForLocation } from "@cosmicds/vue-toolkit/src/mapbox";
 // import { useGeolocation } from "@cosmicds/vue-toolkit";
 const STORY_DATA_URL = `${API_BASE_URL}/planet-parade/data`;
@@ -675,7 +675,6 @@ const wwtSettings: Settings = Settings.get_active();
 function doWWTModifications() {
 
   Grids._makeAltAzGridText = makeAltAzGridText;
-  drawEcliptic;
   Grids.drawEcliptic = drawEcliptic;
 
   // We need to render one frame ahead of time
@@ -691,6 +690,10 @@ function doWWTModifications() {
       showPlanetLabels.value,
     );
   };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  WWTControl.singleton._drawSkyOverlays = drawSkyOverlays.bind(WWTControl.singleton);
 
   // as well as our custom text overlays
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -740,6 +743,7 @@ onMounted(() => {
     store.applySetting(["eclipticColor", Color.fromArgb(255, 255, 0, 255)]);
     store.applySetting(["actualPlanetScale", false]);
     updateAltAzGrid(showAltAzGrid.value);
+    updateAltAzGridText(showHorizon.value);
     updateEcliptic(showEcliptic.value);
     updateConstellations(showConstellations.value);
     updateWWTLocation(selectedLocation.value);
@@ -1033,6 +1037,9 @@ function updateWWTLocation(location: LocationDeg) {
 
 function updateAltAzGrid(show: boolean) {
   store.applySetting(["showAltAzGrid", show]);
+}
+
+function updateAltAzGridText(show: boolean) {
   store.applySetting(["showAltAzGridText", show]);
 }
 
@@ -1063,6 +1070,7 @@ watch(playing, (play: boolean) => {
 watch(showAltAzGrid, updateAltAzGrid);
 watch(showEcliptic, updateEcliptic);
 watch(showConstellations, updateConstellations);
+watch(showHorizon, updateAltAzGridText);
 
 watch(dateTime, (dt: Date) => {
   store.setTime(dt);

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -48,12 +48,12 @@ export function makeAltAzGridText() {
       [[0, alt, -1], "N"],
       [[-sign, alt, 0], "E"],
       [[0, alt, 1], "S"],
-      [[sign, alt,  -0.0095], "V"],
-      [[sign, alt,  0.0095], "V"]
+      [[sign, alt,  0], "W"],
     ]
     directions.forEach(([v, text]) => {
       Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), up, text, 75, 0.00018));
     });
+    useCustomGlyphs(Grids._altAzTextBatch);
   }
 }
 

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -348,3 +348,69 @@ export function drawEcliptic(renderContext: RenderContext, opacity: number, draw
     Grids._eclipticOverviewLineList.drawLines(renderContext, opacity, drawColor);
     return true;
 };
+
+export function drawSkyOverlays() {
+    if (Settings.get_active().get_showConstellationPictures() && !this.freestandingMode) {
+        Constellations.drawArtwork(this.renderContext);
+    }
+    if (Settings.get_active().get_showConstellationFigures()) {
+        if (WWTControl.constellationsFigures == null) {
+            WWTControl.constellationsFigures = Constellations.create(
+                'Constellations',
+                URLHelpers.singleton.engineAssetUrl('figures.txt'),
+                false,  // "boundry"
+                false,  // "noInterpollation"
+                false,  // "resource"
+            );
+        }
+        WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false);
+    }
+    if (Settings.get_active().get_showEclipticGrid()) {
+        Grids.drawEclipticGrid(this.renderContext, 1, Settings.get_active().get_eclipticGridColor());
+        if (Settings.get_active().get_showEclipticGridText()) {
+            Grids.drawEclipticGridText(this.renderContext, 1, Settings.get_active().get_eclipticGridColor());
+        }
+    }
+    if (Settings.get_active().get_showGalacticGrid()) {
+        Grids.drawGalacticGrid(this.renderContext, 1, Settings.get_active().get_galacticGridColor());
+        if (Settings.get_active().get_showGalacticGridText()) {
+            Grids.drawGalacticGridText(this.renderContext, 1, Settings.get_active().get_galacticGridColor());
+        }
+    }
+    if (Settings.get_active().get_showAltAzGrid()) {
+        Grids.drawAltAzGrid(this.renderContext, 1, Settings.get_active().get_altAzGridColor());
+    }
+    if (Settings.get_active().get_showAltAzGridText()) {
+        Grids.drawAltAzGridText(this.renderContext, 1, Settings.get_active().get_altAzGridColor());
+    }
+    if (Settings.get_active().get_showPrecessionChart()) {
+        Grids.drawPrecessionChart(this.renderContext, 1, Settings.get_active().get_precessionChartColor());
+    }
+    if (Settings.get_active().get_showEcliptic()) {
+        Grids.drawEcliptic(this.renderContext, 1, Settings.get_active().get_eclipticColor());
+        if (Settings.get_active().get_showEclipticOverviewText()) {
+            Grids.drawEclipticText(this.renderContext, 1, Settings.get_active().get_eclipticColor());
+        }
+    }
+    if (Settings.get_active().get_showGrid()) {
+        Grids.drawEquitorialGrid(this.renderContext, 1, Settings.get_active().get_equatorialGridColor());
+        if (Settings.get_active().get_showEquatorialGridText()) {
+            Grids.drawEquitorialGridText(this.renderContext, 1, Settings.get_active().get_equatorialGridColor());
+        }
+    }
+    if (Settings.get_active().get_showConstellationBoundries()) {
+        if (WWTControl.constellationsBoundries == null) {
+            WWTControl.constellationsBoundries = Constellations.create(
+                'Constellations',
+                URLHelpers.singleton.engineAssetUrl('constellations.txt'),
+                true,   // "boundry"
+                false,  // "noInterpollation"
+                false,  // "resource"
+            );
+        }
+        WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false);
+    }
+    if (Settings.get_active().get_showConstellationLabels()) {
+        Constellations.drawConstellationNames(this.renderContext, 1, Colors.get_yellow());
+    }
+}


### PR DESCRIPTION
This PR resolves #40 by connecting the visibility of the cardinal direction labels to the horizon/sky setting rather than the sky grid setting. Additionally, it updates the direction labels to use our custom glyph set.