### PR TITLE
Add checkbox to allow skipping intro content

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -93,6 +93,7 @@
 
         </v-card>
       </div>
+      <v-checkbox v-model="skipIntroChecked" label="Don't display intro content again"></v-checkbox>
 
     </v-dialog>
 
@@ -552,8 +553,10 @@ const STORY_DATA_URL = `${API_BASE_URL}/planet-parade/data`;
 
 const UUID_KEY = "eclipse-mini-uuid" as const;
 const OPT_OUT_KEY = "eclipse-mini-optout" as const;
+const SKIP_INTRO_CONTENT_KEY = "skip-intro-content" as const;
 const maybeUUID = window.localStorage.getItem(UUID_KEY);
 const storedOptOut = window.localStorage.getItem(OPT_OUT_KEY);
+const skipIntroContent = window.localStorage.getItem(SKIP_INTRO_CONTENT_KEY) === "true";
 const existingUser = maybeUUID !== null;
 const uuid = maybeUUID ?? v4();
 if (!existingUser) {
@@ -608,6 +611,7 @@ const showPlanetLabels = ref(true);
 const inIntro = ref(false);
 const showPrivacyDialog = ref(false);
 const datePickerOpen = ref(false);
+const skipIntroChecked = ref(skipIntroContent);
 
 const optOut = typeof storedOptOut === "string" ? storedOptOut === "true" : null;
 const responseOptOut = ref(optOut);
@@ -1082,6 +1086,10 @@ watch(showHorizon, updateAltAzGridText);
 
 watch(dateTime, (dt: Date) => {
   store.setTime(dt);
+});
+
+watch(skipIntroChecked, (checked: boolean) => {
+  window.localStorage.setItem(SKIP_INTRO_CONTENT_KEY, String(checked));
 });
 
 watch(showTextSheet, (show: boolean) => {

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -91,9 +91,15 @@
             </ol>
           </div>
 
+          <v-checkbox
+            v-model="skipIntroChecked"
+            label="Don't display intro content again"
+            density="compact"
+            hide-details
+          >
+          </v-checkbox>
         </v-card>
       </div>
-      <v-checkbox v-model="skipIntroChecked" label="Don't display intro content again"></v-checkbox>
 
     </v-dialog>
 
@@ -265,13 +271,25 @@
         show-text
         @reset="()=>{selectedTime = Date.now()}"
         />
-      <div id="change-optout">
+      <div id="change-flags">
         <icon-button
           md-icon="mdi-lock"
           @activate="() => showPrivacyDialog = true"
           :color="accentColor"
           :focus-color="accentColor"
           tooltip-text="Change privacy settings"
+          tooltip-location="bottom"
+          tooltip-offset="5px"
+          :show-tooltip="!mobile"
+          mdSize="1em"
+        >
+        </icon-button>
+        <icon-button
+          md-icon="mdi-help"
+          @activate="() => inIntro = true"
+          :color="accentColor"
+          :focus-color="accentColor"
+          tooltip-text="Show quickstart guide"
           tooltip-location="bottom"
           tooltip-offset="5px"
           :show-tooltip="!mobile"
@@ -556,7 +574,7 @@ const OPT_OUT_KEY = "eclipse-mini-optout" as const;
 const SKIP_INTRO_CONTENT_KEY = "skip-intro-content" as const;
 const maybeUUID = window.localStorage.getItem(UUID_KEY);
 const storedOptOut = window.localStorage.getItem(OPT_OUT_KEY);
-const skipIntroContent = window.localStorage.getItem(SKIP_INTRO_CONTENT_KEY) === "true";
+const skipIntroContent = window.localStorage.getItem(SKIP_INTRO_CONTENT_KEY)?.toLowerCase() === "true";
 const existingUser = maybeUUID !== null;
 const uuid = maybeUUID ?? v4();
 if (!existingUser) {
@@ -590,7 +608,8 @@ const _props = withDefaults(defineProps<PlanetParadeProps>(), {
   wwtNamespace: "planet-parade",
 });
 
-const splash = new URLSearchParams(window.location.search).get("splash")?.toLowerCase() !== "false";
+const queryHideSplash = new URLSearchParams(window.location.search).get("splash")?.toLowerCase() === "false";
+const splash = !(queryHideSplash || skipIntroContent);
 const showSplashScreen = ref(splash);
 const backgroundImagesets = reactive<BackgroundImageset[]>([]);
 const sheet = ref<SheetType | null>(null);
@@ -1794,16 +1813,19 @@ video {
   }
 }
 
-#change-optout {
+#change-flags {
   position: absolute;
   right: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
 
-    @media (max-width: 990px) {
-      bottom: -0.5rem;
-    } 
-    @media (min-width: 948px) {
-      bottom: 40px;
-    }
+  @media (max-width: 990px) {
+    bottom: -0.5rem;
+  }
+  @media (min-width: 948px) {
+    bottom: 40px;
+  }
     
   .icon-wrapper {
     margin: 0;

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -93,8 +93,8 @@
 
           <v-checkbox
             v-model="skipIntroChecked"
-            label="Don't display intro content again"
-            density="compact"
+            label="Do not display Intro Content again"
+            density="default"
             hide-details
           >
           </v-checkbox>
@@ -273,6 +273,18 @@
         />
       <div id="change-flags">
         <icon-button
+          md-icon="mdi-information-outline"
+          @activate="() => inIntro = true"
+          :color="accentColor"
+          :focus-color="accentColor"
+          tooltip-text="Show Quick Start Guide"
+          tooltip-location="bottom"
+          tooltip-offset="5px"
+          :show-tooltip="!mobile"
+          mdSize="1.2em"
+        >
+        </icon-button>
+        <icon-button
           md-icon="mdi-lock"
           @activate="() => showPrivacyDialog = true"
           :color="accentColor"
@@ -281,19 +293,7 @@
           tooltip-location="bottom"
           tooltip-offset="5px"
           :show-tooltip="!mobile"
-          mdSize="1em"
-        >
-        </icon-button>
-        <icon-button
-          md-icon="mdi-help"
-          @activate="() => inIntro = true"
-          :color="accentColor"
-          :focus-color="accentColor"
-          tooltip-text="Show quickstart guide"
-          tooltip-location="bottom"
-          tooltip-offset="5px"
-          :show-tooltip="!mobile"
-          mdSize="1em"
+          mdSize="1.2em"
         >
         </icon-button>
       </div>
@@ -1815,15 +1815,16 @@ video {
 
 #change-flags {
   position: absolute;
-  right: 0.5rem;
   display: flex;
   flex-direction: row;
   gap: 5px;
 
   @media (max-width: 990px) {
-    bottom: -0.5rem;
+    right: 0rem;
+    bottom: 0rem;
   }
   @media (min-width: 948px) {
+    right: 0.5rem;
     bottom: 40px;
   }
     

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -1043,7 +1043,7 @@ async function resetCamera(): Promise<void> {
   );
 
   const sunAz = sunAltAz.azRad;
-  const startAlt = 25 * D2R;
+  const startAlt = smallSize.value ? 15 * D2R : 25 * D2R;
   const startRADec = horizontalToEquatorial(
     startAlt,
     sunAz,


### PR DESCRIPTION
This PR resolves #41. We use local storage to store the user's preference for whether to skip the content or not. If either the query parameter or the local storage tell us to skip the intro, then we skip. The "?" button in the bottom right allows re-displaying the quickstart guide and changing this preference.