### PR TITLE
Make ecliptic fade between day and night colors

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -544,7 +544,7 @@ import { useDisplay } from "vuetify";
 import { v4 } from "uuid";
 
 import { useTimezone } from "./timezones";
-import { horizontalToEquatorial } from "./utils";
+import { horizontalToEquatorial, skyOpacityForSunAlt } from "./utils";
 import { resetAltAzGridText, makeAltAzGridText, drawPlanets, renderOneFrame, drawEcliptic, drawSkyOverlays } from "./wwt-hacks";
 import { MapBoxFeature, MapBoxFeatureCollection, geocodingInfoForSearch, textForLocation } from "@cosmicds/vue-toolkit/src/mapbox";
 // import { useGeolocation } from "@cosmicds/vue-toolkit";
@@ -759,8 +759,6 @@ onMounted(() => {
     //   resetCamera();
     // });
     
-    
-
     createUserEntry();
 
     setInterval(() => {
@@ -768,6 +766,8 @@ onMounted(() => {
         const time = store.currentTime;
         selectedTime.value = time.getTime();
       }
+      const sunPosition = getSunPositionAtTime(store.currentTime);
+      updateEclipticColor(sunPosition.altRad);
     }, 500);
 
     window.addEventListener("keyup", (event: KeyboardEvent) => {
@@ -1037,6 +1037,13 @@ function updateAltAzGridText(show: boolean) {
 function updateEcliptic(show: boolean) {
   store.applySetting(["showEcliptic", show]);
   // store.applySetting(["showEclipticOverviewText", show]);
+}
+
+function updateEclipticColor(sunAlt: number) {
+  const opacity = skyOpacityForSunAlt(sunAlt);
+  const component = 255 - opacity * (255 - 119);
+  const color = Color.fromArgb(255, component, 0, component);
+  store.applySetting(["eclipticColor", color]);
 }
 
 function updateConstellations(show: boolean) {

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -449,7 +449,7 @@
                   The planet parade happens when all the planets happen to be on the same side of their orbits around the Sun as Earth, so they all are on Earth's night-time side. (When a planet is on the opposite side of the Sun during Earth, that means it is up in the sky during the day when the Sun outshines it.) 
                 </p>
                 <p>
-                  <strong>The planets are not really all in a line.</strong> It only appears that way from Earth because Earth and the other planets all orbit the Sun in roughly the same plane (as if they were on a vinyl record). From Earth's point of view, all the other solar system objects appear to move along a circular path around the sky, which ancient astronomers called the "ecliptic." The <span style="color: var(--accent-color)">Ecliptic</span> is displayed as a magenta path in the virtual sky. 
+                  <strong>The planets are not really all in a line.</strong> It only appears that way from Earth because Earth and the other planets all orbit the Sun in roughly the same plane (as if they were on a vinyl record). From Earth's point of view, all the other solar system objects appear to move along a circular path around the sky, which ancient astronomers called the "ecliptic." The <span style="color: var(--accent-color)">Ecliptic</span> is displayed as a purple or magenta path in the virtual sky. 
                 </p>
                 <p>
                   Click <font-awesome-icon class="bullet-icon" icon="video" style="color: #f4ba3e" /> in the upper left to watch a (silent) video showing an overhead view of the planets and how their positions lead to the planet parade.

--- a/src/horizon_sky.ts
+++ b/src/horizon_sky.ts
@@ -19,7 +19,7 @@ import {
 } from "@wwtelescope/engine";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
 import { HorizonSkyOptions } from "./types";
-import { equatorialToHorizontal, horizontalToEquatorial } from "./utils";
+import { equatorialToHorizontal, horizontalToEquatorial, skyOpacityForSunAlt } from "./utils";
 import { D2R, R2D } from "@cosmicds/vue-toolkit";
 
 const sunPlace = new Place();
@@ -55,14 +55,6 @@ export const drawHorizon = (renderContext: RenderContext, options: HorizonSkyOpt
   triangleList.draw(renderContext, 1, true);
 
 };
-
-
-function skyOpacityForSunAlt(sunAltRad: number) {
-  const civilTwilight = -6 * D2R;
-  const astronomicalTwilight = 3 * civilTwilight;
-  
-  return Math.min(Math.max((1 + Math.atan(Math.PI * sunAltRad / (-astronomicalTwilight))) / 2, 0), 1);
-}
 
 
 export const drawSky = (renderContext: RenderContext, options: HorizonSkyOptions) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,3 +107,10 @@ export function equatorialToHorizontal(raRad: number, decRad: number, latRad: nu
   return { altRad: altitude, azRad: azimuth };
 
 }
+
+export function skyOpacityForSunAlt(sunAltRad: number) {
+  const civilTwilight = -6 * D2R;
+  const astronomicalTwilight = 3 * civilTwilight;
+  
+  return Math.min(Math.max((1 + Math.atan(Math.PI * sunAltRad / (-astronomicalTwilight))) / 2, 0), 1);
+}


### PR DESCRIPTION
This PR implements #33. It makes the ecliptic color fade between the "up" and "down" colors by using the opacity of the sky to interpolate.