### PR TITLE
Add WWT usage tracking

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -231,7 +231,25 @@
         :useInline="xs"
         :maxSpeed="10000"
         show-text
-        @reset="()=>{selectedTime = Date.now()}"
+        @reset="() => {
+          selectedTime = Date.now();
+          wwtStats.timeResetCount += 1;
+        }"
+        @update:reverse="(_reverse: boolean) => {
+          wwtStats.reverseCount += 1;
+        }"
+        @update:playing="(_playing: boolean) => {
+          wwtStats.playPauseCount += 1;
+        }"
+        @slow-down="(rate: number) => {
+          wwtStats.slowdowns.push(rate);
+        }"
+        @speed-up="(rate: number) => {
+          wwtStats.speedups.push(rate);
+        }"
+        @rate="(rate: number) => {
+          wwtStats.rateSelections.push(rate);
+        }"
         />
       <div id="change-flags">
         <icon-button
@@ -516,7 +534,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, nextTick, watch } from "vue";
+import { ref, reactive, computed, markRaw, onMounted, nextTick, watch } from "vue";
 import { Color, Grids, Planets, Settings, WWTControl } from "@wwtelescope/engine";
 import { SolarSystemObjects } from "@wwtelescope/engine-types";
 import { engineStore } from "@wwtelescope/engine-pinia";
@@ -595,6 +613,16 @@ const inIntro = ref(false);
 const showPrivacyDialog = ref(false);
 const datePickerOpen = ref(false);
 const skipIntroChecked = ref(skipIntroContent);
+
+const wwtStats = markRaw({
+  timeResetCount: 0,
+  reverseCount: 0,
+  playPauseCount: 0,
+  speedups: [] as number[],
+  slowdowns: [] as number[],
+  rateSelections: [] as number[],
+  startStopTimes: [] as [number, number | null][],
+});
 
 const optOut = typeof storedOptOut === "string" ? storedOptOut === "true" : null;
 const responseOptOut = ref(optOut);
@@ -722,6 +750,7 @@ onMounted(() => {
     if (altTime) {
       selectedTime.value = altTime;
     }
+    wwtStats.startStopTimes.push([selectedTime.value, null]);
     setTimeout(() => resetCamera().then(() => positionSet.value = true), 100);
 
     store.applySetting(["localHorizonMode", true]);
@@ -929,6 +958,20 @@ async function createUserEntry() {
       app_time_ms: 0, info_time_ms: 0, video_time_ms: 0,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       video_opened: videoOpened, video_played: videoPlayed,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_time_reset_count: wwtStats.timeResetCount,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_reverse_count: wwtStats.reverseCount,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_play_pause_count: wwtStats.playPauseCount,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_speedups: wwtStats.speedups,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_slowdowns: wwtStats.slowdowns,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_rate_selections: wwtStats.rateSelections,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_start_stop_times: wwtStats.startStopTimes.filter(pair => pair.every(x => x !== null)),
     }),
   });
 }
@@ -942,6 +985,15 @@ function resetData() {
   appStartTimestamp = now;
   infoStartTimestamp = showTextSheet.value ? now : null;
   videoPlayingStartTimestamp = videoPlaying ? now : null;
+  Object.assign(wwtStats, {
+    timeResetCount: 0,
+    reverseCount: 0,
+    playPauseCount: 0,
+    speedups: [],
+    slowdowns: [],
+    rateSelections: [],
+    startStopTimes: [],
+  });
 }
 
 async function updateUserData() {
@@ -952,6 +1004,10 @@ async function updateUserData() {
   const now = Date.now();
   const infoTime = (showTextSheet.value && infoStartTimestamp !== null) ? now - infoStartTimestamp : infoTimeMs;
   const videoTime = (videoPlaying && videoPlayingStartTimestamp !== null) ? now - videoPlayingStartTimestamp : videoPlayingTimeMs;
+
+  if (wwtStats.startStopTimes.length > 0) {
+    wwtStats.startStopTimes[wwtStats.startStopTimes.length - 1][1] = selectedTime.value;
+  }
 
   fetch(`${STORY_DATA_URL}/${uuid}`, {
     method: "PATCH",
@@ -973,6 +1029,20 @@ async function updateUserData() {
       delta_video_time_ms: videoTime,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       video_opened: videoOpened, video_played: videoPlayed,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      delta_wwt_time_reset_count: wwtStats.timeResetCount,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      delta_wwt_reverse_count: wwtStats.reverseCount,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      delta_wwt_play_pause_count: wwtStats.playPauseCount,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_speedups: wwtStats.speedups,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_slowdowns: wwtStats.slowdowns,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_rate_selections: wwtStats.rateSelections,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wwt_start_stop_times: wwtStats.startStopTimes.filter(pair => pair.every(x => x !== null)),
     }),
     keepalive: true,
   }).then(() => {

--- a/src/components/PlaybackControl.vue
+++ b/src/components/PlaybackControl.vue
@@ -70,7 +70,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-// import VueSlider from 'vue-slider-component';
 import { VSlider } from 'vuetify/components/VSlider';
 import { SymmetricalLogTransform, symmLinspace } from './symlog';
 

--- a/src/components/SpeedControl.vue
+++ b/src/components/SpeedControl.vue
@@ -9,6 +9,7 @@
           () => {
             reverseOrIncreaseReversePlaybackRate();
             timePlaying = true;
+            emit('update:reverse', playbackRate < 0);
           }
         "
         :color="color"
@@ -31,6 +32,7 @@
             } else {
               forwardOrIncreaseForwardPlaybackRate();
             }
+            emit('speed-up', playback);
           }
         "
         :color="color"
@@ -81,7 +83,7 @@
       ></icon-button> -->
       <icon-button
         @activate="() => {
-          reverseRate()
+          reverseRate();
         }"
         :md-icon="playbackRate < 0 ? 'mdi-step-forward-2' : 'mdi-step-backward-2'"
         :color="color"
@@ -100,6 +102,7 @@
         @activate="
           () => {
             timePlaying = !timePlaying;
+            emit('update:playing', timePlaying);
           }
         "
         :color="color"
@@ -119,6 +122,7 @@
           () => {
             decreaseRate();
             timePlaying = true;
+            emit('slow-down', playbackRate);
           }
         "
         :color="color"
@@ -138,6 +142,7 @@
           () => {
             increaseRate();
             timePlaying = true;
+            emit('speed-up', playbackRate);
           }
         "
         :color="color"
@@ -300,7 +305,6 @@ const {
   store, 
   showText, 
   rateDelta, 
-  useOldControl, 
   useInline
 } = withDefaults(defineProps<Props>(),
   {
@@ -319,7 +323,14 @@ const {
 const playing = defineModel<boolean>('playing', {default: false, required: true});
 const minSpeed = 1;
 
-const emit = defineEmits(['reset', 'update:playing']);
+const emit = defineEmits<{
+  "reset": void,
+  "update:reverse": boolean,
+  "update:playing": boolean,
+  "slow-down": number,
+  "speed-up": number
+  "rate": number
+}>();
 
 const playbackVisible = ref(false);
 const forceRate = ref(false);


### PR DESCRIPTION
This PR resolves #60 by recording several values related to the usage of WWT for a given user. For a description of the fields that are added to the database, see https://github.com/cosmicds/cds-api/pull/174. Testing this PR also requires pointing the `STORY_DATA_URL` to point to a locally running version of the server using that PR. To keep track of these values, this PR updates the speed control component to emit some new events that allow the main component to keep track of which of its buttons have been pressed.

@patudom @johnarban  I'm open to any thoughts on these values/additional values to track.