### PR TITLE
Add planet visibility indicator

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -155,7 +155,7 @@
         <span tabindex="0" id="my-location-label" class="elevation-1" @click="showLocationSelector=true" @keyup.enter="showLocationSelector=true">{{ xSmallSize ? 'Location' : 'Current location'}}: {{ selectedLocationText != '' ? selectedLocationText : 'Cambridge, MA (default)' }}</span>
       </div>
       <div id="right-buttons">
-        <div id="controls" class="control-icon-wrapper">
+        <div id="controls" class="collapsable-control control-icon-wrapper">
           <div id="controls-top-row">
             <font-awesome-icon
               size="lg"
@@ -179,6 +179,30 @@
               <v-checkbox :color="accentColor" v-model="showConstellations" @keyup.enter="showConstellations = !showConstellations"
               label="Constellations" hide-details />
 
+          </div>
+        </div>
+        
+        <div id="planet-visibility-box" class="collapsable-control control-icon-wrapper">
+          <div id="controls-top-row">
+            Planet Visibility&nbsp;&nbsp;
+            <font-awesome-icon
+              size="lg"
+              class="tab-focusable"
+              :color="accentColor"
+              :icon="showPlanetVisiblity ? `chevron-down` : `chevron-up`"
+              @click="showPlanetVisiblity = !showPlanetVisiblity" 
+              @keyup.enter="showPlanetVisiblity = !showPlanetVisiblity"
+              tabindex="0" />
+          </div>
+        
+          <div v-if="showPlanetVisiblity" id="planet-visibility-label">
+            <p class="planet-label"><v-icon>mdi-eye-outline</v-icon> Mercury</p>
+            <p class="planet-label not-visible"><v-icon>mdi-eye-outline</v-icon> Venus</p>
+            <p class="planet-label"><v-icon>mdi-eye-outline</v-icon> Mars</p>
+            <p class="planet-label not-visible"><v-icon>mdi-eye-outline</v-icon> Jupiter</p>
+            <p class="planet-label"><v-icon>mdi-eye-outline</v-icon> Saturn</p>
+            <p class="planet-label"><v-icon>mdi-binoculars</v-icon> Uranus</p>
+            <p class="planet-label"><v-icon>mdi-telescope</v-icon> Neptune</p>
           </div>
         </div>
       </div>
@@ -613,6 +637,7 @@ const inIntro = ref(false);
 const showPrivacyDialog = ref(false);
 const datePickerOpen = ref(false);
 const skipIntroChecked = ref(skipIntroContent);
+const showPlanetVisiblity = ref(true);
 
 const wwtStats = markRaw({
   timeResetCount: 0,
@@ -1341,7 +1366,7 @@ li {
   height: auto;
 }
 
-#controls {
+.collapsable-control {
   pointer-events: auto;
 
   background: black;
@@ -1410,6 +1435,21 @@ li {
     width: 100%;
     flex-direction: row;
     justify-content: flex-end;
+  }
+}
+
+#planet-visibility-box {
+  color: var(--accent-color);
+  // font-size: calc(1.1 * var(--default-font-size));
+  
+  #planet-visibility-label {
+      
+    p.planet-label {
+      margin: 0;
+      margin-left: 0.5em;
+      line-height: calc(1 * var(--default-line-height));
+      
+    }
   }
 }
 

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -233,7 +233,7 @@
             tabindex="0"
             @keyup.enter="props.onClick"
             >
-            <time-display class="bsn__time" :date="localSelectedDate" ampm :short-time-date="smAndDown" show-timezone :timezone="shortTimezone" />
+            <time-display class="bsn__time" :date="localSelectedDate" ampm :short-time-date="true" show-timezone :timezone="shortTimezone" />
             <v-icon v-if="!(smAndDown || mobile)" class="td__icon"  >mdi-cursor-default-click</v-icon>
           </v-card>
         </template>
@@ -1504,6 +1504,7 @@ li {
   pointer-events: none;
   align-items: center;
   gap: 5px;
+  justify-content: center;
 }
 
 // vuetify smAndDown
@@ -1856,13 +1857,16 @@ video {
   display: flex;
   align-items: center;
   gap: 1rem;
+  margin-left: 1rem;
+  margin-top: 2px;
 
   @media (max-width: 600px) {
-    margin: 0;
+    // margin: 0;
+    // margin-left: 1rem;
   }
 
   @media (min-width: 601px) {
-    margin: 1rem;
+    // margin: 1rem;
   }
 
 }
@@ -1885,7 +1889,7 @@ video {
 }
 
 .td__card {
-  border: 1px solid var(--accent-color);
+  border: 2px solid var(--accent-color);
   text-align: right;
   position: relative;
   overflow: visible;
@@ -1901,6 +1905,14 @@ video {
 .bsn__time .td__time_time {
   font-size: var(--default-font-size);
 }
+
+@media (min-width: 960px) {
+  .bsn__time .td__time_time.td__short_time {
+    font-size: calc(1.2 * var(--default-font-size));
+  }
+}
+
+
 
 .bsn__time .td__date_date {
   font-size: calc(0.85 * var(--default-font-size));

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -156,7 +156,7 @@
       </div>
       <div id="right-buttons">
         <div id="controls" class="collapsable-control control-icon-wrapper">
-          <div id="controls-top-row">
+          <div class="controls-top-row">
             <font-awesome-icon
               size="lg"
               class="tab-focusable"
@@ -183,8 +183,8 @@
         </div>
         
         <div id="planet-visibility-box" class="collapsable-control control-icon-wrapper">
-          <div id="controls-top-row">
-            Planet Visibility&nbsp;&nbsp;
+          <div class="controls-top-row planet-visibility">
+            <div class="planet-visibility-title">Above Horizon</div>
             <font-awesome-icon
               size="lg"
               class="tab-focusable"
@@ -196,6 +196,7 @@
           </div>
           <!-- {{ planetIsVisible(SolarSystemObjects.sun, dateTime,  selectedLocation) }} -->
           <div v-if="showPlanetVisiblity" id="planet-visibility-label">
+            <p :class="['planet-label','sun', sunVis ? '' : 'not-visible' ]"><v-icon>mdi-weather-sunny</v-icon> Sun</p>
             <p :class="['planet-label', mercuryVis ? '' : 'not-visible' ]"><v-icon>mdi-eye-outline</v-icon> Mercury</p>
             <p :class="['planet-label', venusVis   ? '' : 'not-visible' ]"><v-icon>mdi-eye-outline</v-icon> Venus</p>
             <p :class="['planet-label', marsVis    ? '' : 'not-visible' ]"><v-icon>mdi-eye-outline</v-icon> Mars</p>
@@ -774,6 +775,7 @@ function planetIsVisible(planetName, date: Date, location: LocationDeg) {
   return altAz.altRad > 0;
 }
 
+const sunVis = computed(() => planetIsVisible(SolarSystemObjects.sun, dateTime.value, selectedLocation.value));
 const mercuryVis = computed(() => planetIsVisible(SolarSystemObjects.mercury, dateTime.value, selectedLocation.value));
 const venusVis = computed(() => planetIsVisible(SolarSystemObjects.venus, dateTime.value, selectedLocation.value));
 const marsVis = computed(() => planetIsVisible(SolarSystemObjects.mars, dateTime.value, selectedLocation.value));
@@ -1447,7 +1449,7 @@ li {
     }
   }
   
-  #controls-top-row {
+  .controls-top-row {
     padding-left: 0.5em;
     display: flex;
     width: 100%;
@@ -1458,15 +1460,34 @@ li {
 
 #planet-visibility-box {
   color: var(--accent-color);
-  // font-size: calc(1.1 * var(--default-font-size));
+  font-size: calc(1.15 * var(--default-font-size));
+  
+  .controls-top-row.planet-visibility {
+    justify-content: space-between;
+  }
+  
+  .planet-visibility-title {
+    // flex-basis: 12ch;
+    line-height: calc(1 * var(--default-line-height));
+    margin-bottom: 5px;
+    margin-right: 5px;
+  }
   
   #planet-visibility-label {
       
     p.planet-label {
+      font-size: calc(1.1 * var(--default-font-size));
       margin: 0;
       margin-left: 0.5em;
       line-height: calc(1 * var(--default-line-height));
+      transition: color 0.3s;
     }
+    
+    .sun {
+      color: rgb(232, 232, 59);
+      font-weight: bold;
+    }
+
     p.planet-label.not-visible {
       color: #333;
     }

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -1460,7 +1460,7 @@ li {
 
 #planet-visibility-box {
   color: var(--accent-color);
-  font-size: calc(1.15 * var(--default-font-size));
+  font-size: calc(1.1 * var(--default-font-size));
   
   .controls-top-row.planet-visibility {
     justify-content: space-between;
@@ -1476,7 +1476,7 @@ li {
   #planet-visibility-label {
       
     p.planet-label {
-      font-size: calc(1.1 * var(--default-font-size));
+      font-size: var(--default-font-size);
       margin: 0;
       margin-left: 0.5em;
       line-height: calc(1 * var(--default-line-height));

--- a/src/components/TimeDisplay.vue
+++ b/src/components/TimeDisplay.vue
@@ -12,7 +12,7 @@
         <span class="td__timezone_tz">{{ props.timezone }}</span>
       </div>
       <div class="td__time" v-if="props.shortTimeDate"> 
-        <span class="td__time_time">{{ shortTimeDateString }}</span>
+        <span class="td__time_time td__short_time">{{ shortTimeDateString }}</span>
       </div>
       
    </div>  
@@ -58,6 +58,7 @@ const ampm = computed(() => {
 
 const shortTimeDateString = computed(() => {
   // return date formatted as Oct 3 9:00 AM
+  const year = props.date.getFullYear();
   const month = props.date.toLocaleString('default', { month: 'short' });
   const day = props.date.getDate();
   const h = props.date.getHours() % 12;
@@ -65,7 +66,7 @@ const shortTimeDateString = computed(() => {
   const minute = pad(props.date.getMinutes());
   const ampm = props.date.getHours() >= 12 ? 'PM' : 'AM';
   const tz =  props.timezone;
-  return `${month} ${day} ${hour}:${minute} ${ampm}` + (props.showTimezone ? ` ${tz}` : '');
+  return `${month} ${day} ${year} ${hour}:${minute} ${ampm}` + (props.showTimezone ? ` ${tz}` : '');
 });
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import {
   faBookOpen,
   faChevronDown,
+  faChevronUp,
   faCircleXmark,
   faGear,
   faLocationDot,
@@ -42,6 +43,7 @@ import {
 
 library.add(faBookOpen);
 library.add(faChevronDown);
+library.add(faChevronUp);
 library.add(faCircleXmark);
 library.add(faGear);
 library.add(faLocationDot);

--- a/src/shims-wwt.d.ts
+++ b/src/shims-wwt.d.ts
@@ -1,4 +1,5 @@
 import { Color, RenderContext } from "@wwtelescope/engine";
+import { SolarSystemObjects } from "@wwtelescope/engine-types";
 
 declare module "@wwtelescope/engine" {
 
@@ -68,6 +69,18 @@ declare module "@wwtelescope/engine" {
 
   export class CAAMoon {
     static radiusVector(JD: number): number;
+  }
+  
+  export class AstroRaDec {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    RA: number;
+    dec: number;
+    distance: number;
+    constructor(ra: number, dec: number, distance: number, shadow?: boolean, eclipsed?: boolean);
+  }
+  
+  export class AstroCalc {
+    static getPlanet(jDate: number, planetName: SolarSystemObjects, lat: number, lng: number, height: number): AstroRaDec;
   }
 
 }


### PR DESCRIPTION
Add a visibility dialog for planets, allowing users to see which planets are currently visible based on their location and time. Fade out planet label when it is below the horizon. 

When time is played very fast, there can be a lag between when the planet is below the horizon and when the ui indicates this. 