### PR TITLE
Increase timeout for starting camera setup

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -796,7 +796,7 @@ onMounted(() => {
       selectedTime.value = altTime;
     }
     wwtStats.startTime = selectedTime.value;
-    setTimeout(() => resetCamera().then(() => positionSet.value = true), 200);
+    setTimeout(() => resetCamera().then(() => positionSet.value = true), 300);
 
     store.applySetting(["localHorizonMode", true]);
     store.applySetting(["altAzGridColor", Color.fromArgb(180, 133, 201, 254)]);

--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -796,7 +796,7 @@ onMounted(() => {
       selectedTime.value = altTime;
     }
     wwtStats.startTime = selectedTime.value;
-    setTimeout(() => resetCamera().then(() => positionSet.value = true), 100);
+    setTimeout(() => resetCamera().then(() => positionSet.value = true), 200);
 
     store.applySetting(["localHorizonMode", true]);
     store.applySetting(["altAzGridColor", Color.fromArgb(180, 133, 201, 254)]);


### PR DESCRIPTION
This PR attempts to resolve #72 by increasing the timeout for the initial camera setup from 100 ms -> 200 ms.