### PR TITLE
don't show rater for now

### DIFF
--- a/src/PlanetParade.vue
+++ b/src/PlanetParade.vue
@@ -560,7 +560,7 @@
   <v-container>
     <v-expand-transition>
       <user-experience
-        v-if="showRating"
+        v-hide="true"
         :question="question"
         icon-size="3x"
         @dismiss="(_rating: UserExperienceRating | null, _comments: string | null) => {


### PR DESCRIPTION
I'm not sure why, but on the deployed app, the user experience ratings are not being pushed to the db. I get a `403 Forbidden` error. (The deployed app does still write to the `PlanetParadeData` table, so I'm not sure why the user experience ratings aren't going through with the same API key).

(The user experience ratings do get written to the db when I run the Planet Parade from localhost).

If the system thinks you haven't rated a story, the rater will keep popping up every time you load the page, which I think will be annoying, so I am hiding the rater until @Carifio24 or @johnarban is back and able to take a look.

(We should think separately about whether dismissing the rating box with the `mdi-close` should send an "opt out" to the db so the rater doesn't keep appearing for users who try to send it away).